### PR TITLE
Added leaflet-marker-icon/shadow class

### DIFF
--- a/src/leaflet.extra-markers.js
+++ b/src/leaflet.extra-markers.js
@@ -62,19 +62,21 @@
         _setIconStyles: function (img, name) {
             var options = this.options,
                 size = L.point(options[name === 'shadow' ? 'shadowSize' : 'iconSize']),
-                anchor;
+                anchor, leafletName;
 
             if (name === 'shadow') {
                 anchor = L.point(options.shadowAnchor || options.iconAnchor);
+                leafletName = 'shadow';
             } else {
                 anchor = L.point(options.iconAnchor);
+                leafletName = 'icon';
             }
 
             if (!anchor && size) {
                 anchor = size.divideBy(2, true);
             }
 
-            img.className = 'extra-marker-' + name + ' ' + options.className;
+            img.className = 'leaflet-marker-' + leafletName + ' extra-marker-' + name + ' ' + options.className;
 
             if (anchor) {
                 img.style.marginLeft = (-anchor.x) + 'px';


### PR DESCRIPTION
for compatibility with Leaflet.markercluster animations (see Leaflet/Leaflet.markercluster#598). These classes are used on the default L.Icon.Default, but were omitted in Awesome Markers and Extra Markers. They do not bring any additional styling beyond what Extra Markers assigns to .extra-marker (position: absolute; left: 0; top: 0; user-select: none; display: block;) except for "user-select: none;".