### PR TITLE
Ability to insert own HTML instead of predefined icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Now use the plugin to create a marker like this:
 | Property        | Description                  | Default Value | Possible  values                                     |
 | --------------- | ---------------------------- | ------------- | ---------------------------------------------------- |
 | icon            | Name of the icon WITH prefix | 'fa-home'     | See glyphicons or font-awesome (must include prefix)  |
+| innerHTML       | own HTML code                | ''            | can be used to use SVG or PNG files |
 | prefix          | Select de icon library       | 'glyphicon'   | 'fa' for font-awesome or 'glyphicon' for bootstrap 3 |
 | markerColor     | Color of the marker          | 'blue'        | 'red', 'orange-dark', 'orange', 'yellow', 'blue-dark', 'cyan', 'purple', 'violet', 'pink', 'green-dark', 'green', 'green-light', 'black', 'white' |
 | shape           | Shape of the marker          | 'circle'      | 'circle', 'square', 'star', 'penta' |

--- a/src/assets/js/leaflet.extra-markers.js
+++ b/src/assets/js/leaflet.extra-markers.js
@@ -22,6 +22,7 @@
             extraClasses: "",
             shape: "circle",
             icon: "",
+            innerHTML: "",
             markerColor: "red",
             iconColor: "#fff",
             number: ""
@@ -33,6 +34,9 @@
             var div = document.createElement("div"), options = this.options;
             if (options.icon) {
                 div.innerHTML = this._createInner();
+            }
+            if (options.innerHTML) {
+                div.innerHTML = options.innerHTML;
             }
             if (options.bgPos) {
                 div.style.backgroundPosition = -options.bgPos.x + "px " + -options.bgPos.y + "px";


### PR DESCRIPTION
Allows you to use HTML inside (well, on top of) the marker. I use this to add SVG icons to your lovely markers!

use like this:

```javascript
var science = L.ExtraMarkers.icon({
	markerColor: 'white',
	shape: 'square',
	innerHTML: '<img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/Aperture_Science.svg" width="20px" height="20px" style="margin-top: 8px;">'
});

L.marker([51.941196,4.512291], {icon: science}).addTo(map);
```

The `margin-top` is probably not ideal, but i also did not want to introduce huge amounts of CSS changes - which other people might need to workaround in turn.