### PR TITLE
fix custom class name

### DIFF
--- a/src/assets/js/leaflet.extra-markers.js
+++ b/src/assets/js/leaflet.extra-markers.js
@@ -9,7 +9,7 @@
             popupAnchor: [ 1, -32 ],
             shadowAnchor: [ 10, 12 ],
             shadowSize: [ 36, 16 ],
-            className: "extra-marker",
+            className: "",
             prefix: "",
             extraClasses: "",
             shape: "circle",
@@ -84,7 +84,7 @@
             if (!anchor && size) {
                 anchor = size.divideBy(2, true);
             }
-            img.className = "leaflet-marker-" + leafletName + " extra-marker-" + name + " " + options.className;
+            img.className = "leaflet-marker-" + leafletName + " extra-marker extra-marker-" + name + " " + options.className;
             if (anchor) {
                 img.style.marginLeft = -anchor.x + "px";
                 img.style.marginTop = -anchor.y + "px";


### PR DESCRIPTION
If I create an icon with a custom className option, the marker background is not displayed because of overriding the predefined className.

The leaflet docs mention a empty className property for icons ([Link](http://leafletjs.com/reference-1.0.0.html#icon-classname)). Therefore I think it's best to follow the leaflet docs and also leave the className option empty.
