### PR TITLE
Added text popups to markers on demo page

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -130,3 +130,16 @@ L.marker([32.995, -117.240], {
         markerColor: 'white'
     })
 }).addTo(map);
+
+//adds pop up to each marker 
+map.eachLayer(function (layer) {
+    if(layer._icon && layer._icon.className.includes('leaflet-marker-icon')) {
+        var popUpTextArray = [];
+        console.log(layer)
+        popUpTextArray.push('icon: ' + layer.options.icon.options.icon);
+        popUpTextArray.push('shape: ' + layer.options.icon.options.shape);
+        popUpTextArray.push('markerColor: ' + layer.options.icon.options.markerColor);
+        var popUpText = popUpTextArray.join('<br />');
+        layer.bindPopup(popUpText);
+    }
+});


### PR DESCRIPTION
Now when a user clicks on a marker they find out what icon, shape and color was used to make that marker. This makes looking up a certain marker attribute from the demo a little faster for users. 